### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,3 @@ updates:
       interval: "weekly"
     assignees:
       - "HarlemSquirrel"
-    reviewers:
-      - "HarlemSquirrel"


### PR DESCRIPTION
Remove deprecated dependabot config

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/